### PR TITLE
Fix CI release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,8 +4,6 @@ on:
     paths-ignore:
       - 'tests/fixtures/**.json'
       - '**.md'
-    tags-ignore:
-      - "*"
 
 jobs:
   unit-tests:
@@ -43,26 +41,3 @@ jobs:
         run: npm start
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  tag:
-    name: Semantic versioning
-    runs-on: ubuntu-latest
-    needs: action
-    steps:
-      - name: checkout repository
-        uses: actions/checkout@v3
-      - name: setup NodeJS
-        uses: actions/setup-node@v2
-        with:
-          node-version-file: '.nvmrc'
-      - name: Automatically tag next version
-        uses: paulhatch/semantic-version@v4.0.2
-        with:
-          tag_prefix: "v"
-          major_pattern: "(MAJOR)"
-          minor_pattern: "(MINOR)"
-          change_path: "src"
-          namespace: emissary
-          bump_each_commit: false
-          search_commit_body: true
-          user_format_type: "csv"
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Release
+on:
+  push:
+    branches:    
+      - main
+
+jobs:
+  tag:
+    name: Semantic versioning
+    runs-on: ubuntu-latest
+    needs: action
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+      - name: setup NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Automatically tag next version
+        uses: paulhatch/semantic-version@v4.0.2
+        with:
+          tag_prefix: "v"
+          major_pattern: "(MAJOR)"
+          minor_pattern: "(MINOR)"
+          change_path: "src"
+          namespace: emissary
+          bump_each_commit: false
+          search_commit_body: true
+          user_format_type: "csv"


### PR DESCRIPTION
Currently workflow isn't triggered anymore. So probably split the workflow in 2 separate ones, and run semantic release only on `main`.