### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,16 +1,21 @@
 name: Release
 on:
-  push:
-    branches:    
-      - main
+  workflow_run:
+    workflows: [CI]
+    branches: [main]
+    types: 
+      - completed
 
 jobs:
   tag:
     name: Semantic versioning
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: setup NodeJS
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Release workflow must be triggered only when CI workflow is completed and successful.
Release workflow needs to access Git history and tags.