### PR TITLE
Expose dry-run as an action input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,4 @@ jobs:
         id: emissary
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
         id: emissary
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          dry-run: 'false'
+          dry-run: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
         id: emissary
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          dry-run: 'true'
+          dry-run: 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
         id: emissary
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          dry-run: 'true'
+          dryrun: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,3 @@ jobs:
         id: emissary
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          dryrun: 'true'

--- a/action.yaml
+++ b/action.yaml
@@ -12,3 +12,7 @@ inputs:
   token:
     description: 'Github Token'
     required: true
+  dryrun:
+    description: 'Execute action without replying or resolving any pull request review thread'
+    default: 'false'
+    required: false

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   token:
     description: 'Github Token'
     required: true
-  dry-run:
+  dryrun:
     description: 'Execute action without replying or resolving any pull request review thread'
     default: 'false'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -10,3 +10,7 @@ inputs:
   token:
     description: 'Github Token'
     required: true
+  dry-run:
+    description: 'Execute action without replying or resolving any pull request review thread'
+    default: 'false'
+    required: false

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ const handle = async ({
     const action = act === 'reply' ? 'marked it as done' : 'resolved it'
     let message = `@${contributor ?? 'unknown'} ${action} in ${sha}`
     if (extra) message = `${message}\n${extra}`
-    if (process.env.DRY_RUN) {
+    if (process.env.DRY_RUN || process.env.INPUT_DRY_RUN === 'true') {
       warning(`[dry-run] would have sent ${message}`)
       return true
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ const handle = async ({
     const action = act === 'reply' ? 'marked it as done' : 'resolved it'
     let message = `@${contributor ?? 'unknown'} ${action} in ${sha}`
     if (extra) message = `${message}\n${extra}`
-    if (process.env.DRY_RUN || process.env.INPUT_DRY_RUN === 'true') {
+    if (process.env.DRYRUN || process.env.INPUT_DRYRUN === 'true') {
       warning(`[dry-run] would have sent ${message}`)
       return true
     }


### PR DESCRIPTION
allows for executing all the logic of the action, preventing from replying or resolving at the end